### PR TITLE
Support for Jersey 2.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+### 2.0.0
+* **deps:** Upgraded to Java 8 as baseline (possibly breaking change)
+* **deps:** Upgraded to support Jersey 2.34 onwards
+* **bug:** Fix response being truncated and unparsable when it is not buffered in memory
+
 ### 1.0.0 - 2018-01-05
 
 * **feat:** add ability to modify snippet base URI (scheme, host, port) (closes [#7](https://github.com/RESTDocsEXT/restdocsext-jersey/issues/7))

--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,12 @@ apply from: "gradle/checkstyle.gradle"
 apply from: "gradle/pmd.gradle"
 apply from: "gradle/bintray-publish.gradle"
 
-sourceCompatibility = '1.7'
+sourceCompatibility = '1.8'
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 ext {
-    jerseyVersion = '2.10.4'
-    springRestdocsVersion = '2.0.0.RELEASE'
+    jerseyVersion = '2.35'
+    springRestdocsVersion = '2.0.5.RELEASE'
     javadocLinks = [
 		'http://docs.oracle.com/javase/8/docs/api/',
 		"http://docs.spring.io/spring-restdocs/docs/$springRestdocsVersion/api/"
@@ -60,6 +60,7 @@ dependencies {
     testCompile 'org.powermock:powermock-core:1.6.3'
     testCompile 'org.powermock:powermock-api-mockito:1.6.3'
     testCompile 'org.powermock:powermock-module-junit4:1.6.3'
+    testCompile "org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion"
     testCompile "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:$jerseyVersion"
     testCompile "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:$jerseyVersion"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 
 group = io.github.restdocsext
-version = 1.0.1-SNAPSHOT
+version = 2.0.0-SNAPSHOT
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 10 19:43:36 ICT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-bin.zip

--- a/src/main/java/io/github/restdocsext/jersey/JerseyRequestConverter.java
+++ b/src/main/java/io/github/restdocsext/jersey/JerseyRequestConverter.java
@@ -48,8 +48,6 @@ import org.springframework.restdocs.operation.QueryStringParser;
 import org.springframework.restdocs.operation.RequestConverter;
 import org.springframework.util.StringUtils;
 
-import jersey.repackaged.com.google.common.collect.Lists;
-
 import static io.github.restdocsext.jersey.DocumentationProperties.REQUEST_BODY_KEY;
 
 /**
@@ -230,7 +228,7 @@ class JerseyRequestConverter implements RequestConverter<ClientRequest> {
     }
 
     private static List<String> objectListToStringList(List<Object> source) {
-        final List<String> converted = Lists.newArrayList();
+        final List<String> converted = new ArrayList<>();
         for (Object obj : source) {
             converted.add(obj.toString());
         }

--- a/src/main/java/io/github/restdocsext/jersey/JerseyResponseConverter.java
+++ b/src/main/java/io/github/restdocsext/jersey/JerseyResponseConverter.java
@@ -38,7 +38,7 @@ class JerseyResponseConverter implements ResponseConverter<ClientResponse> {
     @Override
     public OperationResponse convert(ClientResponse response) {
         return new OperationResponseFactory().create(
-                HttpStatus.valueOf(response.getStatus()),
+                response.getStatus(),
                 extractHeaders(response.getHeaders()),
                 extractContent(response));
     }

--- a/src/main/java/io/github/restdocsext/jersey/JerseyRestDocumentationFilter.java
+++ b/src/main/java/io/github/restdocsext/jersey/JerseyRestDocumentationFilter.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.Priority;
 import javax.ws.rs.client.ClientRequestContext;
@@ -34,7 +35,6 @@ import org.springframework.restdocs.generate.RestDocumentationGenerator;
 import org.springframework.restdocs.snippet.Snippet;
 
 import io.github.restdocsext.jersey.DocumentationProperties.ProviderPriorities;
-import jersey.repackaged.com.google.common.base.Preconditions;
 
 import static io.github.restdocsext.jersey.DocumentationProperties.CONTEXT_CONFIGURATION_KEY;
 import static io.github.restdocsext.jersey.DocumentationProperties.PATH_BUILDER_KEY;
@@ -55,7 +55,7 @@ public class JerseyRestDocumentationFilter implements ClientResponseFilter {
 
     JerseyRestDocumentationFilter(
             RestDocumentationGenerator<ClientRequest, ClientResponse> delegate) {
-        Preconditions.checkNotNull(delegate, "delegate must not be null");
+        Objects.requireNonNull(delegate, "delegate must not be null");
         this.delegate = delegate;
     }
 

--- a/src/main/java/io/github/restdocsext/jersey/ResponseInterceptor.java
+++ b/src/main/java/io/github/restdocsext/jersey/ResponseInterceptor.java
@@ -59,7 +59,15 @@ public class ResponseInterceptor implements ClientResponseFilter {
         }
         in.mark(maxEntitySize + 1);
         final byte[] entity = new byte[maxEntitySize + 1];
-        final int entitySize = in.read(entity);
+        int cursor = 0;
+        while(cursor <= maxEntitySize) {
+            int chunkSize = in.read(entity, cursor, entity.length - cursor);
+            cursor += chunkSize;
+            if (chunkSize < 1) {
+                break;
+            }
+        }
+        final int entitySize = cursor+1;
         b.append(new String(entity, 0, Math.min(entitySize, maxEntitySize), charset));
         if (entitySize > maxEntitySize) {
             b.append("...more...");

--- a/src/main/java/io/github/restdocsext/jersey/client/RestdocsClientBuilder.java
+++ b/src/main/java/io/github/restdocsext/jersey/client/RestdocsClientBuilder.java
@@ -18,6 +18,9 @@ package io.github.restdocsext.jersey.client;
 
 import java.security.KeyStore;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -147,6 +150,30 @@ public class RestdocsClientBuilder extends ClientBuilder {
     @Override
     public RestdocsClientBuilder register(Object component, Map<Class<?>, Integer> contracts) {
         this.delegate.register(component, contracts);
+        return this;
+    }
+
+    @Override
+    public ClientBuilder executorService(ExecutorService executorService) {
+        this.delegate.executorService(executorService);
+        return this;
+    }
+
+    @Override
+    public ClientBuilder scheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
+        this.delegate.scheduledExecutorService(scheduledExecutorService);
+        return this;
+    }
+
+    @Override
+    public ClientBuilder connectTimeout(long timeout, TimeUnit unit) {
+        this.delegate.connectTimeout(timeout, unit);
+        return this;
+    }
+
+    @Override
+    public ClientBuilder readTimeout(long timeout, TimeUnit unit) {
+        this.delegate.readTimeout(timeout, unit);
         return this;
     }
 }

--- a/src/main/java/io/github/restdocsext/jersey/client/RestdocsWebTarget.java
+++ b/src/main/java/io/github/restdocsext/jersey/client/RestdocsWebTarget.java
@@ -18,6 +18,7 @@ package io.github.restdocsext.jersey.client;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
@@ -28,7 +29,6 @@ import javax.ws.rs.core.UriBuilder;
 import org.glassfish.jersey.client.JerseyWebTarget;
 
 import io.github.restdocsext.jersey.JerseyRestDocumentationFilter;
-import jersey.repackaged.com.google.common.base.Preconditions;
 
 import static io.github.restdocsext.jersey.DocumentationProperties.DOCS_FILTER_KEY;
 import static io.github.restdocsext.jersey.DocumentationProperties.PATH_BUILDER_KEY;
@@ -76,7 +76,7 @@ public final class RestdocsWebTarget implements WebTarget {
 
     @Override
     public RestdocsWebTarget path(String path) throws NullPointerException {
-        Preconditions.checkNotNull(path, "path is 'null'.");
+        Objects.requireNonNull(path, "path is 'null'.");
         getBuilderProperty(PATH_BUILDER_KEY).append(getNormalizedPath(path));
         return new RestdocsWebTarget(this.delegate.path(path));
     }

--- a/src/main/java/io/github/restdocsext/jersey/operation/preprocess/BinaryPartPlaceholderOperationPreprocessor.java
+++ b/src/main/java/io/github/restdocsext/jersey/operation/preprocess/BinaryPartPlaceholderOperationPreprocessor.java
@@ -19,6 +19,7 @@ package io.github.restdocsext.jersey.operation.preprocess;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.restdocs.operation.OperationRequest;
 import org.springframework.restdocs.operation.OperationRequestFactory;
@@ -26,8 +27,6 @@ import org.springframework.restdocs.operation.OperationRequestPart;
 import org.springframework.restdocs.operation.OperationRequestPartFactory;
 import org.springframework.restdocs.operation.preprocess.OperationPreprocessor;
 import org.springframework.restdocs.operation.preprocess.OperationPreprocessorAdapter;
-
-import jersey.repackaged.com.google.common.base.Preconditions;
 
 /**
  * {@link OperationPreprocessor} to add placeholder content for binary multipart fields.
@@ -54,7 +53,7 @@ public final class BinaryPartPlaceholderOperationPreprocessor
      * @return the multipart field
      */
     public BinaryPartPlaceholderOperationPreprocessor field(String name) {
-        Preconditions.checkNotNull(name, "field name must not be null");
+        Objects.requireNonNull(name, "field name must not be null");
         final MultiPartField field = new MultiPartField(name, null);
         this.fields.add(field);
         return this;
@@ -68,8 +67,8 @@ public final class BinaryPartPlaceholderOperationPreprocessor
      * @return the operation preprocessor instance.
      */
     public BinaryPartPlaceholderOperationPreprocessor field(String name, String placeholder) {
-        Preconditions.checkNotNull(name, "field name must not be null");
-        Preconditions.checkNotNull(placeholder, "placeholder must not be null");
+        Objects.requireNonNull(name, "field name must not be null");
+        Objects.requireNonNull(placeholder, "placeholder must not be null");
         final MultiPartField field = new MultiPartField(name, placeholder);
         this.fields.add(field);
         return this;

--- a/src/test/java/io/github/restdocsext/jersey/JerseyRestDocumentationIntegrationTest.java
+++ b/src/test/java/io/github/restdocsext/jersey/JerseyRestDocumentationIntegrationTest.java
@@ -27,7 +27,7 @@ import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.glassfish.jersey.filter.LoggingFilter;
+import org.glassfish.jersey.logging.LoggingFeature;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
@@ -52,7 +52,7 @@ import static io.github.restdocsext.jersey.test.SnippetMatchers.httpRequest;
 import static io.github.restdocsext.jersey.test.SnippetMatchers.snippet;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -101,7 +101,7 @@ public class JerseyRestDocumentationIntegrationTest extends JerseyTest {
     public ResourceConfig configure() {
         return new ResourceConfig(TestResource.class)
                 .register(MultiPartFeature.class)
-                .register(LoggingFilter.class);
+                .register(LoggingFeature.class);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class JerseyRestDocumentationIntegrationTest extends JerseyTest {
 
     @Test
     public void curl_snippet_with_content() {
-        final String contentType = "text/plain; charset=UTF-8";
+        final String contentType = "text/plain;charset=UTF-8";
         final Response response = target()
                 .register(documentationConfiguration(this.restDocumentation))
                 .register(document("curl-snippet-with-content",
@@ -154,7 +154,7 @@ public class JerseyRestDocumentationIntegrationTest extends JerseyTest {
         assertThat(new File("build/generated-snippets/curl-get-with-query-string/curl-request.adoc"),
                 is(snippet(asciidoctor()).withContents(codeBlock(asciidoctor(), "bash").content(
                                         "$ curl "
-                                        + "'http://localhost:8080/test/get-default?a=alpha&b=bravo' -i"))));
+                                        + "'http://localhost:8080/test/get-default?a=alpha&b=bravo' -i -X GET"))));
     }
 
     @Test

--- a/src/test/java/io/github/restdocsext/jersey/test/Mocks.java
+++ b/src/test/java/io/github/restdocsext/jersey/test/Mocks.java
@@ -18,6 +18,7 @@ package io.github.restdocsext.jersey.test;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.Collections;
@@ -37,6 +38,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.http.HttpHeaders;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -138,6 +140,16 @@ public final class Mocks {
                         }
                     });
             when(this.clientRequest.resolveProperty(anyString(), any())).thenAnswer(
+                    new Answer<Object>() {
+                        @Override
+                        public Object answer(InvocationOnMock invocation) throws Throwable {
+                            String prop = invocation.getArgumentAt(0, String.class);
+                            final Object value = ClientRequestBuilder.this.configProps.get(prop);
+                            return value == null ? invocation.getArguments()[1] : value;
+                        }
+                    });
+            // any doesn't suffice for array-type arguments.
+            when(this.clientRequest.resolveProperty(anyString(), any(Array.class))).thenAnswer(
                     new Answer<Object>() {
                         @Override
                         public Object answer(InvocationOnMock invocation) throws Throwable {


### PR DESCRIPTION
I wanted to use this project with recent release of Jersey, but discovered that it uses shaded version of guava that used to ship with Jersey a long time ago.

I therefore removed these references, adapted to new internal InjectionManager APIs.

Along the way I moved baseline Java to 8, as it is also baseline java version of Jersey for at least 4 years now.